### PR TITLE
Execute tests with correct MPI settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,27 @@ option(
   OFF
 )
 
+set(
+  SCALAPACKFX_TEST_OMP_THREADS
+  "1"
+  CACHE STRING
+  "Nr. of OpenMP-threads used for testing"
+)
+
+set(SCALAPACKFX_TEST_MPI_PROCS
+  "1"
+  CACHE STRING
+  "Nr. of MPI processes used for testing"
+)
+
+set(
+  SCALAPACKFX_MPIEXEC_POSTFLAGS
+  ""
+  CACHE STRING
+  "Additional flags for the mpiexec command (to be added after the mpiexec command name)"
+)
+
+
 #[=============================================================================[
 #                  Project configuration                                      #
 ]=============================================================================]
@@ -73,6 +94,13 @@ set(BUILD_SHARED_LIBS ${SCALAPACKFX_BUILD_SHARED_LIBS})
 scalapackfx_setup_build_type("RelWithDebInfo")
 
 find_package(MPI REQUIRED)
+
+set(
+  MPI_TEST_RUNNER
+  ${MPIEXEC_PREFLAGS} ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${SCALAPACKFX_TEST_MPI_PROCS}
+  ${MPIEXEC_POSTFLAGS} ${SCALAPACKFX_MPIEXEC_POSTFLAGS}
+)
+
 
 #
 # Prerequisites

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,10 @@
 # Folder for generated mod-files
 set(moduledir "${CMAKE_CURRENT_BINARY_DIR}/modules")
 
+add_library(blacstestutils blacstestutils.f90)
+target_link_libraries(blacstestutils PRIVATE scalapackfx)
+target_link_libraries(blacstestutils PRIVATE Fortuno::fortuno_mpi)
+
 list(APPEND tests
   test_desc
 #  test_cpg2l
@@ -16,18 +20,23 @@ list(APPEND tests
 #  test_tran
 )
 
+
 foreach(test IN LISTS tests)
   add_executable(${test})
   target_sources(${test} PRIVATE ${test}.f90)
   set_target_properties(
     ${test} PROPERTIES Fortran_MODULE_DIRECTORY "${moduledir}"
   )
+  target_link_libraries(${test} PRIVATE blacstestutils)
   target_link_libraries(${test} PRIVATE scalapackfx)
   target_link_libraries(${test} PRIVATE Fortuno::fortuno_mpi MPI::MPI_Fortran)
   target_link_libraries(${test} PRIVATE Scalapack::Scalapack)
-
   add_test(
     NAME ${test}
-    COMMAND ${test}
+    COMMAND  ${MPI_TEST_RUNNER} ./${test}
+  )
+  set_tests_properties(
+    ${test}
+    PROPERTIES ENVIRONMENT OMP_NUM_THREADS=${SCALAPACKFX_TEST_OMP_THREADS}
   )
 endforeach()

--- a/test/blacstestutils.f90
+++ b/test/blacstestutils.f90
@@ -1,0 +1,157 @@
+module blacstestutils
+  use libscalapackfx_module, only : blacsgrid, blacsfx_exit, blacsfx_pinfo
+  use fortuno_mpi, only : test_item, mpi_case, check => mpi_check, failed => mpi_failed, num_ranks
+  implicit none
+
+  private
+  public :: this_proc, num_procs
+  public :: blacs_test
+  public :: blacs_grid_env, get_grid_or_fail
+
+
+  !> Implements a test class with BLACS initialization and destruction
+  type, extends(mpi_case) :: blacs_case
+  contains
+    procedure :: run => blacs_case_run
+  end type blacs_case
+
+
+  abstract interface
+    !> Interface of the test procedure
+    subroutine blacs_test_procedure()
+    end subroutine blacs_test_procedure
+  end interface
+
+
+  !> Implements a BLACS grid wrapper enforcing grid finalization
+  type, extends(blacsgrid) :: blacs_grid_env
+
+    !> Whether the grid contains all BLACS processes
+    logical :: has_all_procs = .false.
+  contains
+    final :: final_blacs_grid_env
+  end type blacs_grid_env
+
+
+  ! Number of processes available in the BLACS framework
+  integer :: num_procs_ = -1
+
+  ! The id of the current process in the BLACS framework
+  integer :: this_proc_ = -1
+
+contains
+
+
+  !> Returns the id of the current process in the BLACS framework
+  function this_proc()
+    integer :: this_proc
+    this_proc = this_proc_
+  end function this_proc
+
+
+  !> Returns the number for processes available in the BLACS framework
+  function num_procs()
+    integer :: num_procs
+    num_procs = num_procs_
+  end function num_procs
+
+
+  !> Wraps a blacs_case instance as test_item suitable for array constructors.
+  function blacs_test(name, proc) result(testitem)
+    character(*), intent(in) :: name
+    procedure(blacs_test_procedure) :: proc
+
+    type(test_item) :: testitem
+
+    testitem = test_item(blacs_case(name=name, proc=proc))
+
+  end function blacs_test
+
+
+  !> Run procedure of the tempfile_case type.
+  subroutine blacs_case_run(this)
+    class(blacs_case), intent(in) :: this
+
+    call blacsfx_pinfo(this_proc_, num_procs_)
+    call check(num_procs_ == num_ranks(),&
+        & "Number of BLACS processes differ from number of MPI ranks")
+    if (failed()) return
+    call this%proc()
+    call blacsfx_exit(keepmpi=.true.)
+    this_proc_ = -1
+    num_procs_ = -1
+
+  end subroutine blacs_case_run
+
+
+  !> Returns a grid environment or sets the calling test to failed if not possible
+  !!
+  !! Note: This routine must be called from within fortuno MPI test procedures.
+  !!
+  subroutine get_grid_or_fail(this, nrow, ncol, includeall)
+
+    !> Instance
+    type(blacs_grid_env), intent(out) :: this
+
+    !> Number of process rows
+    integer, optional, intent(in) :: nrow
+
+    !> Number of process columns
+    integer, optional, intent(in) :: ncol
+
+    !> Whether it should be ensured that all processes are included in the grid (default: .true.)
+    logical, optional, intent(in) :: includeall
+
+    integer :: nprocs
+    integer :: nrow_, ncol_
+    logical :: includeall_, hasall
+    type(blacsgrid) :: grid
+
+    includeall_ = .true.
+    if (present(includeall)) includeall_ = includeall
+
+    nprocs = num_procs()
+    if (present(nrow) .and. present(ncol)) then
+      nrow_ = nrow
+      ncol_ = ncol
+    else if (present(nrow)) then
+      nrow_ = nrow
+      ncol_ = nprocs / nrow_
+    else if (present(ncol)) then
+      ncol_ = ncol
+      nrow_ = nprocs / ncol_
+    else if (includeall_) then
+      do nrow_ = floor(sqrt(real(nprocs))), 1, -1
+        ncol_ = nprocs / nrow_
+        if (ncol_ * nrow_ == nprocs) exit
+      end do
+    else
+      nrow_ = floor(sqrt(real(nprocs)))
+      ncol_ = nprocs / nrow_
+    end if
+    hasall = ncol_ * nrow_ == nprocs
+
+    call check(nrow_ * ncol_ <= nprocs, msg="Required grid needs more processes than available")
+    if (failed()) return
+    call check(nrow_ > 0, msg="Could not set up grid with at least one process row")
+    if (failed()) return
+    call check(ncol_ > 0, msg="Could not set up grid with at least one process column")
+    if (failed()) return
+    call check(.not. includeall_ .or. hasall,&
+        & msg="Could not include all processes in the required grid")
+    if (failed()) return
+
+    call this%blacsgrid%initgrid(nrow_, ncol_)
+    this%has_all_procs = hasall
+
+  end subroutine get_grid_or_fail
+
+
+  subroutine final_blacs_grid_env(this)
+    type(blacs_grid_env), intent(inout) :: this
+
+    call this%blacsgrid%destruct()
+
+  end subroutine final_blacs_grid_env
+
+end module blacstestutils

--- a/test/test_desc.f90
+++ b/test/test_desc.f90
@@ -1,11 +1,13 @@
 !> Test app driving Fortuno unit tests.
 module test_scalapackfx
   use libscalapackfx_module
-  use fortuno_mpi, only : global_comm, is_equal, test => mpi_case_item, check => mpi_check,&
-      & test_list, this_rank
+  use fortuno_mpi, only : check => mpi_check, failed => mpi_failed, skip => mpi_skip, test_list
+  use blacstestutils, only : blacs_grid_env, get_grid_or_fail, test => blacs_test,&
+      & num_procs
   implicit none
 
 contains
+
 
   function tests()
     type(test_list) :: tests
@@ -18,41 +20,32 @@ contains
 
 
   subroutine test_desc()
-    type(blacsgrid) :: myGrid
-    type(blocklist) :: block_List
+    type(blacs_grid_env) :: env
+    type(blocklist) :: blist
     integer :: desc(DLEN_)
-    integer :: ii, iGlob, iLoc, nElem
-    integer :: iProc, nProc, nGrid
+    integer :: ii, iglob, iloc, nelem
 
-    call blacsfx_pinfo(iProc, nProc)
-
-    nGrid = floor(sqrt(real(nProc)))
-
-    call myGrid%initgrid(2, 2)
-
-    call check(.false.)
-
-    if (myGrid%mycol == -1) then
-
-      print *, "IDLE Node:", iProc, " Exiting..."
-
-    else
-
-      call scalafx_getdescriptor(myGrid, 5, 5, 2, 2, desc)
-      call block_List%init(myGrid, desc, "c")
-      do ii = 1, size(block_List)
-        call block_List%getblock(ii, iGlob, iLoc, nElem)
-        print "(6(A,I3,2X))", "PROW:", myGrid%myrow, "PCOL:", myGrid%mycol,&
-            & "II:", ii, "GLOB:", iGlob, "LOC:", iLoc, "NEL:", nElem
-      end do
-
+    if (num_procs() /= 4) then
+      call skip()
+      return
     end if
 
-    ! THEN each rank must contain source rank's value
-    !call check(is_equal(buffer, sourceval))
-    call check(.false.)
+    call get_grid_or_fail(env, nrow=2, ncol=2)
+    if (failed()) return
 
-    call blacsfx_exit()
+    if (env%mycol == -1) then
+      print *, "IDLE Node:", env%iproc, " Exiting..."
+    else
+      call scalafx_getdescriptor(env%blacsgrid, 5, 5, 2, 2, desc)
+      call blist%init(env%blacsgrid, desc, "c")
+      do ii = 1, size(blist)
+        call blist%getblock(ii, iglob, iloc, nelem)
+        print "(6(A,I3,2X))", "PROW:", env%myrow, "PCOL:", env%mycol,&
+            & "II:", ii, "GLOB:", iglob, "LOC:", iloc, "NEL:", nelem
+      end do
+    end if
+
+    call check(.false.)
 
   end subroutine test_desc
 


### PR DESCRIPTION
This should ensure, that tests are executed with the correct MPI environment. This fixes the problem of the passing tests. It does not fix the Fortuno issues (generating warnings about multiple finalization).